### PR TITLE
Fixed parsing of ocamldep output for post 3.12 versions.

### DIFF
--- a/Ocaml/src/ocaml/build/graph/DependenciesSetter.java
+++ b/Ocaml/src/ocaml/build/graph/DependenciesSetter.java
@@ -459,7 +459,7 @@ public class DependenciesSetter implements IPostNeededFilesVisitor {
 			for (int j = allFiles.length - 1; j > 0; j--) {
 				// Ignorer les noms de fichiers vides, ceci peut arriver suite à
 				// la concaténation des noms de fichiers avec espaces.
-				if (!allFiles[j].equals("")) {
+				if (!allFiles[j].equals("") && !allFiles[j].equals(":")) {
 					String tempFileName = allFiles[j].replaceAll("\\.cmi\\z",
 							".mli");
 					tempFileName = tempFileName.replaceAll("\\.cmo\\z", ".ml");


### PR DESCRIPTION
ocamldep version 4.01 adds an extra space to its output that causes OcaIDE to try to use a file named ":"

```
diff 3.12.assert.ml-deps 4.01.assert.ml-deps 
1,2c1,2
< assert.cmo: assert.cmi
< assert.cmx: assert.cmi

---
> assert.cmo : assert.cmi
> assert.cmx : assert.cmi
```

This results in the mysterious error message: "Path must include project and resource name: /:"

This patch fixes the problem while retaining backward compatibility by ignoring any file named ":" when parsing the ocamldep output.
